### PR TITLE
Updated AMIs 

### DIFF
--- a/cfn/teamInstancesDsDef.template
+++ b/cfn/teamInstancesDsDef.template
@@ -81,8 +81,8 @@
   "Mappings" : {
     "AMIs" : {
       "us-east-1" : {
-        "atk" : "ami-052dab13",
-        "defvtm" : "ami-862ea890"
+        "atk" : "ami-bae465ac",
+        "defvtm" : "ami-a4e465b2"
       }
     }
   },


### PR DESCRIPTION
Upgraded Agent on ATK to 10.x (previous version not in atom feed for module support, activated/installed all needed modules for VTM including AppControl.